### PR TITLE
Update WMC package version to 2.5.5

### DIFF
--- a/WMC-JsonConsoleWrapper/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/WMC-JsonConsoleWrapper/Properties/PublishProfiles/FolderProfile.pubxml
@@ -11,8 +11,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>true</SelfContained>
-    <PublishSingleFile>True</PublishSingleFile>
-    <PublishReadyToRun>True</PublishReadyToRun>
-    <PublishTrimmed>False</PublishTrimmed>
+    <PublishSingleFile>true</PublishSingleFile>
+    <PublishReadyToRun>true</PublishReadyToRun>
   </PropertyGroup>
 </Project>

--- a/WMC-JsonConsoleWrapper/WMC-JsonConsoleWrapper.csproj
+++ b/WMC-JsonConsoleWrapper/WMC-JsonConsoleWrapper.csproj
@@ -13,7 +13,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Dubya.WindowsMediaController" Version="2.1.0" />
+    <PackageReference Include="Dubya.WindowsMediaController" Version="2.5.5" />
   </ItemGroup>
 
 </Project>

--- a/WMC-JsonConsoleWrapper/WMC-JsonConsoleWrapper.csproj
+++ b/WMC-JsonConsoleWrapper/WMC-JsonConsoleWrapper.csproj
@@ -6,10 +6,16 @@
     <RootNamespace>WMC-JsonConsoleWrapper</RootNamespace>
     <ApplicationIcon />
     <StartupObject />
+    <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
     <PlatformTarget>x86</PlatformTarget>
+    <DebugType>embedded</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DebugType>embedded</DebugType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
fixes a crash caused by The Device Is Not Ready error

not sure if it would break any of the rest of the code, but shouldnt I dont think